### PR TITLE
Code Listing Drag Command and a new list command

### DIFF
--- a/Commands/Create Table.plist
+++ b/Commands/Create Table.plist
@@ -7,41 +7,55 @@
 	<key>command</key>
 	<string>#!/usr/bin/env ruby
 
-require "#{ENV['TM_SUPPORT_PATH']}/lib/exit_codes.rb"
-require "#{ENV['TM_SUPPORT_PATH']}/lib/ui.rb"
+		require "#{ENV['TM_SUPPORT_PATH']}/lib/exit_codes.rb"
+		require "#{ENV['TM_SUPPORT_PATH']}/lib/ui.rb"
 
-if ENV.has_key?('TM_SELECTED_TEXT') then
-  result=ENV['TM_SELECTED_TEXT']
-else
-  result = TextMate::UI.request_string(
-    :title =&gt; 'LaTeX Array Creation', 
-    :prompt =&gt; 'Number of rows and columns:',
-    :default =&gt; '6 4',
-    :button1 =&gt; 'Create'
-  )
-  TextMate.exit_discard if result.nil?
-end
-# print "Result: #{result}"
-m = /(\d+)\D+(\d+)/.match(result.to_s)
-exit if m.nil?
-rows, columns = m[1].to_i, m[2].to_i
-# print "Rows: #{rows}"
-# print "Columns: #{columns}"
-print "\\begin{tabular}{"
-columns.times {print("c")}
-puts "}"
-puts "\\hline\n"
-n=0
-rows.times do |r|
-  (columns-1).times do |c|
-    n+=1
-    print "${#{n}:r#{r+1}c#{c+1}} &amp; "
-  end
-  n+=1
-  print "${#{n}:r#{r+1}c#{columns}}\\\\\\\\\n"
-  puts "\\hline\n"
-end
-puts "\\end{tabular}"
+		if ENV.has_key?('TM_SELECTED_TEXT') then
+		  result=ENV['TM_SELECTED_TEXT']
+		else
+		  result = TextMate::UI.request_string(
+		    :title =&gt; 'LaTeX Array Creation', 
+		    :prompt =&gt; 'Number of rows and columns:',
+		    :default =&gt; '6 4',
+		    :button1 =&gt; 'Create'
+		  )
+		  TextMate.exit_discard if result.nil?
+		end
+		# print "Result: #{result}"
+		m = /(\d+)\D+(\d+)/.match(result.to_s)
+		exit if m.nil?
+		rows, columns = m[1].to_i, m[2].to_i
+		# print "Rows: #{rows}"
+		# print "Columns: #{columns}"
+		print "\\begin{table}[htb!]
+			\\caption{\\it \${1:caption}}
+			\\label{table:\${2:label}}
+			\\centering
+			\\begin{tabular}{"
+		(columns-1).times {print("c ")}
+		puts "c}
+				\\toprule\n"
+		n=3
+		rows.times do |r|
+		  (columns-1).times do |c|
+		    n+=1
+			if r == 0
+				print "		\\textbf{${#{n}:Header #{c+1}}} &amp; "
+			else
+				print "		${#{n}:r#{r+1}c#{c+1}} &amp; "
+			end
+		  end
+		  n+=1
+			if r == 0
+				print "		\\textbf{${#{n}:Header #{columns}}}\\\\\\\\\n"
+			else
+				print "			${#{n}:r#{r+1}c#{columns}}\\\\\\\\\n"
+			end
+
+		  end
+		puts "		\\toprule
+			\\end{tabular}
+		\\end{table}"
 </string>
 	<key>input</key>
 	<string>none</string>

--- a/DragCommands/Insert Code Listing.plist
+++ b/DragCommands/Insert Code Listing.plist
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/usr/bin/env ruby
+require 'pathname'
+require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/LaTeXUtils.rb"
+filename = ENV["TM_DROPPED_FILEPATH"]
+relative_to = ENV["TM_DIRECTORY"]
+startfile = ENV['TM_LATEX_MASTER'] || ENV['TM_FILEPATH']
+master = Pathname.new(LaTeX.master(startfile))
+unless master.absolute?
+  master = master.expand_path(ENV['TM_PROJECT_DIRECTORY'])
+end
+path = Pathname.new(filename).relative_path_from(master.dirname)
+if ENV["TM_MODIFIER_FLAGS"].match(/SHIFT/)
+  print "\\\\input{" + path + "}"
+else
+  ext = File.extname(path)
+  file_type = case ext
+    when ".ada" then "Ada"
+    when ".ant" then "Ant"
+    when ".asm" then "Assembler"
+    when ".as" then "Assembler"
+    when ".c" then "C"
+    when ".cpp" then "C++"
+    when ".htm" then "HTML"
+    when ".html" then "HTML"
+    when ".java" then "Java"
+    when ".js" then "Java"
+    when ".json" then "Java"
+    when ".pl" then "Perl"
+    when ".php" then "PHP"
+    when ".py" then "Python"
+    when ".rb" then "Ruby"
+    when ".sh" then "sh"
+    when ".sql" then "SQL"
+    when ".xml" then "XML"
+    when ".vhdl" then "VHDL"
+    else "language"
+  end
+  puts ["\\\\lstinputlisting[language=\${1:#{file_type}}, tabsize = \${2:4}, caption={\${3:caption}}, label = {code:\${4:#{path.to_s.gsub(/(\.[^.]*$)|(\.\.\/)/,"").gsub(/\//,"_")}}]{#{path}}"].join("\n")
+end</string>
+	<key>draggedFileExtensions</key>
+	<array>
+		<string>ada</string>
+		<string>ant</string>
+		<string>asm</string>
+		<string>as</string>
+		<string>c</string>
+		<string>cpp</string>
+		<string>htm</string>
+		<string>html</string>
+		<string>java</string>
+		<string>js</string>
+		<string>json</string>
+		<string>pl</string>
+		<string>php</string>
+		<string>py</string>
+		<string>rb</string>
+		<string>sh</string>
+		<string>sql</string>
+		<string>xml</string>
+		<string>vhdl</string>
+	</array>
+	<key>input</key>
+	<string>selection</string>
+	<key>name</key>
+	<string>Insert Code Listing</string>
+	<key>output</key>
+	<string>insertAsSnippet</string>
+	<key>scope</key>
+	<string>text.tex.latex</string>
+	<key>uuid</key>
+	<string>404AC956-0D69-4E51-A0F0-771321A0914F</string>
+</dict>
+</plist>


### PR DESCRIPTION
I used the Image Drag Command to create a Code Listing Drag Command, so you can drag Latex Listing recognized source code languages (not all of them… must be completed) to create the listing.

I also improved the Create Table command, so it's with a complete set of tags.