### PR TITLE
Watch PDF fix for Lion

### DIFF
--- a/Support/bin/latex_watch.pl
+++ b/Support/bin/latex_watch.pl
@@ -101,7 +101,7 @@ main_loop();
 		init_prefs() unless defined $prefs;
 		
         my $pref = $prefs->objectForKey_($prefName);
-        return ( ref($pref) eq 'NSCFString'
+        return ( ref($pref) eq '__NSCFString'
             ? $pref->UTF8String()
             : $default)
     }


### PR DESCRIPTION
Added the 2 underscores to NSCFString to fix this check for Lion. Though perhaps it would be better to check wether the UTF8String function exists in the prefs object?
