### PR TITLE
Improved Show Outline command

### DIFF
--- a/Commands/Show Outline.tmCommand
+++ b/Commands/Show Outline.tmCommand
@@ -16,8 +16,15 @@ INCLUDE_REGEX = /\\(?:input|include)(?:%.*\n[ \t]*)?(?&gt;\{(.*?)\})/
 NON_COMMENT_REGEX = /^([^%]+$|(?:[^%]|\\%)*)(?=%|$)/
 class String
   def adjust_end(new_piece)
-    new_form = self.sub(/[^\/]*$/,new_piece)
-    new_form += ".tex" unless new_form.match(/\.tex$/)
+    master = LaTeX.master(ENV['TM_LATEX_MASTER'] || ENV['TM_FILEPATH']) 
+    new_form = self
+    unless master == self
+      masterdir = File.dirname(master)
+      new_form = File.expand_path(new_piece, masterdir)
+    else 
+      new_form = self.sub(/[^\/]*$/,new_piece)
+    end
+    new_form += ".tex" unless new_form.match(/\.tex$/) or File.exists?(new_form)
     new_form
   end
 end


### PR DESCRIPTION
The old version assumed the inputs/includes were relative to the file where the \input/\includes are located, while this should be relative to the master file. I fixed this by determining the path of the master file.
Furthermore, I think the extension of .tex should only be included in case the filename of the included/inputted does not exist. 
