### PR TITLE
Update Commands/Bibliography Completion.plist

### DIFF
--- a/Commands/Bibliography Completion.plist
+++ b/Commands/Bibliography Completion.plist
@@ -13,7 +13,9 @@ phrase = STDIN.read.chomp
 include LaTeX
 begin
 	items = LaTeX.get_citations.map{|i| i.citekey + "   % "+i.description}
-  items = items.grep(/#{phrase}/) if phrase != ""
+  if ((phrase != "") && (phrase != "{}"))
+  	items = items.grep(/#{phrase}/) 
+  end
   TextMate.exit_discard if items.empty?
   if items.length &gt; 1
   	choice = TextMate::UI.menu(items)


### PR DESCRIPTION
BUGFIX: TextMate 2 failed to show all available references when carat is located between a pair of empty curly braces after a cite command
