### PR TITLE
Updating fileTypes in Syntaxes/TeX.plist

### DIFF
--- a/Syntaxes/TeX.plist
+++ b/Syntaxes/TeX.plist
@@ -6,6 +6,8 @@
 	<array>
 		<string>sty</string>
 		<string>cls</string>
+		<string>bbx</string>
+		<string>cbx</string>
 	</array>
 	<key>name</key>
 	<string>TeX</string>


### PR DESCRIPTION
I add bbx and cbx to fileTypes so the bundle can directly handle bibliography styles.
