### PR TITLE
fixes for tm2 image drag-drop snippet

### DIFF
--- a/DragCommands/Include Image.plist
+++ b/DragCommands/Include Image.plist
@@ -24,9 +24,9 @@ when /SHIFT/
 else
   puts ["\\\\begin{figure}[\${1:htbp}]",
 "	\\\\centering",
-"		\\\\includegraphics[width=\${1:.9\\textwidth}]{#{path}}",
-"	\\\\caption{\${4:caption}}",
-"	\\\\label{fig:\${5:#{path.to_s.gsub(/(\.[^.]*$)|(\.\.\/)/,"").gsub(/\//,"_")}}}",
+"		\\\\includegraphics[width=\${2:.9\\textwidth}]{#{path}}",
+"	\\\\caption{\${3:caption}}",
+"	\\\\label{fig:\${4:#{path.to_s.gsub(/(\.[^.]*$)|(\.\.\/)/,"").gsub(/\//,"_")}}}",
 "\\\\end{figure}"].join("\n")
 end</string>
 	<key>draggedFileExtensions</key>


### PR DESCRIPTION
Existing version does not compile as incorrect image width is inserted.
