### PR TITLE
Fix file scanner.

### DIFF
--- a/Support/lib/LaTeXUtils.rb
+++ b/Support/lib/LaTeXUtils.rb
@@ -200,7 +200,7 @@ module LaTeX
     def recursive_scan
        raise "No root specified!" if @root.nil?
        raise "Could not find file #{@root}" unless File.exist?(@root)
-       text = File.read(@root)
+       text = File.readlines(@root)
        text.each_with_index do |line, index|
          includes.each_pair do |regexp, block|
            line.scan(regexp).each do |m|


### PR DESCRIPTION
'Label based on Current Word' Command failed with:

```
/Users/inz/Library/Application Support/TextMate/Managed/Bundles/LaTeX.tmbundle/Support/lib/LaTeXUtils.rb:204:in `recursive_scan': undefined method `each_with_index' for #<String:0x007ff981024d60> (NoMethodError)
    from /Users/inz/Library/Application Support/TextMate/Managed/Bundles/LaTeX.tmbundle/Support/lib/LaTeXUtils.rb:234:in `label_scan'
    from /Users/inz/Library/Application Support/TextMate/Managed/Bundles/LaTeX.tmbundle/Support/lib/LaTeXUtils.rb:57:in `get_labels'
    from Label Based on Current Word / Selection…:8:in `<main>'
```

This is on 10.9 Mavericks with system ruby `ruby 2.0.0p247 (2013-06-27 revision 41674) [universal.x86_64-darwin13]`.
