### PR TITLE
Fix file scan

### DIFF
--- a/Support/lib/LaTeXUtils.rb
+++ b/Support/lib/LaTeXUtils.rb
@@ -100,9 +100,9 @@ module LaTeX
       @@paths ||= Hash.new
       @@paths[extension] ||= ([`#{texpath}kpsewhich -show-path=#{extension}`.chomp.split(/:!!|:/)].flatten.map{|i| i.sub(/\/*$/,'/')}).unshift(relative).unshift("")
       @@paths[extension].each do |path|
-        testpath = File.expand_path(File.join(path,filename))
-        return testpath if File.exist?(testpath)
         testpath = File.expand_path(File.join(path,filename + "." + extension))
+        return testpath if File.exist?(testpath)
+        testpath = File.expand_path(File.join(path,filename))
         return testpath if File.exist?(testpath)
       end
       return nil


### PR DESCRIPTION
Now also works if there is a file (e.g. `chapter1.tex`) with the same name as a project subdirectory (e.g. `chapter1`). 

Before, the file scanner would return the directory name instead of the file name.
