### PR TITLE
[NEW] run makeglossaries command if glsdefs file exists

### DIFF
--- a/Support/bin/texMate.py
+++ b/Support/bin/texMate.py
@@ -152,7 +152,21 @@ def run_makeindex(fileName,idxfile=None):
         warning += w
         stat = runObj.wait()
     return stat,fatal,error,warning
-
+    
+    
+def run_makeglossaries():
+    """Run makeglossaries"""
+    # call biber without extension.
+    fatal,err,warn = 0,0,0
+    runObj = Popen('makeglossaries'+" "+fileNoSuffix,shell=True,stdout=PIPE,stdin=PIPE,stderr=STDOUT,close_fds=True)
+    bp = MakeGlossariesParser(runObj.stdout,verbose)
+    f,e,w = bp.parseStream()
+    fatal|=f
+    err+=e
+    warn+=w
+    stat = runObj.wait()
+    return stat,fatal,err,warn
+    
 def findViewerPath(viewer,pdfFile,fileName):
     """Use the find_app command to ensure that the viewer is installed in the system
        For apps that support pdfsync search in pdf set up the command to go to the part of
@@ -587,7 +601,10 @@ if __name__ == '__main__':
             texStatus, isFatal, numErrs, numWarns = run_bibtex(texfile=fileName)
         
     elif texCommand == 'index':
-        texStatus, isFatal, numErrs, numWarns = run_makeindex(fileName)
+        if os.path.exists(fileNoSuffix+'.glsdefs'):
+            texStatus, isFatal, numErrs, numWarns = run_makeglossaries()
+        else:
+            texStatus, isFatal, numErrs, numWarns = run_makeindex(fileName)
     
     elif texCommand == 'clean':
         texCommand = 'latexmk.pl -CA '
@@ -680,7 +697,10 @@ if __name__ == '__main__':
         print '<div id="texActions">'
         print '<input type="button" value="Re-Run %s" onclick="runLatex(); return false" />' % engine
         print '<input type="button" value="Run Bib" onclick="runBibtex(); return false" />'
-        print '<input type="button" value="Run Makeindex" onclick="runMakeIndex(); return false" />'
+        if os.path.exists(fileNoSuffix+'.glsdefs'):
+            print '<input type="button" value="Make Glossaries" onclick="runMakeIndex(); return false" />'
+        else:
+            print '<input type="button" value="Run Makeindex" onclick="runMakeIndex(); return false" />'
         print '<input type="button" value="Clean up" onclick="runClean(); return false" />'        
         if viewer == 'TextMate':
             pdfFile = fileNoSuffix+'.pdf'


### PR DESCRIPTION
The package glossaries (http://www.ctan.org/pkg/glossaries) provides a flexible solution to manage acronyms and symbols. It comes with the makeglossaries perl script which automates the whole indexing process. So this is my favorite list of acronyms and symbols package.
The current latex.tmbundle only implements the makeindex command. Thus this pull request add a implementation to run the makeglossaries command if the glsdefs file exists. Following changes are made:
- Add the run_makelossaries() method to texMate.py which will call the makeglossaries command and parse the Output with the MakeGlossariesParser
- Change the behavior of `texCommand == 'index'` which will now call the run_makeglossaries() method if the glsdef file exist. If this file not exists it will still run the makeindex command
- Change the button "Run Makeindex" to "Make Glossaries" if the glsdef file exits.
- Add MakeGlossariesParser Class to texparser.py to provides basic Parse of the Error Messages form the makeglossaires command
