### PR TITLE
set default encoding utf-8

### DIFF
--- a/Support/bin/texMate.py
+++ b/Support/bin/texMate.py
@@ -45,6 +45,9 @@ from urllib import quote
 from struct import *
 from texparser import *
 
+reload(sys)
+sys.setdefaultencoding("utf-8")
+
 DEBUG = False
 
 try:


### PR DESCRIPTION
fix bug when building latex file with name in utf-8

For example, if file name is in Chinese, following exception will happen:

Traceback (most recent call last):
File "/Users/tb/Library/Application Support/TextMate/Managed/Bundles/LaTeX.tmbundle/Support/bin/texMate.py", line 615, in texStatus,isFatal,numErrs,numWarns = run_latex(texCommand,fileName,verbose) File "/Users/tb/Library/Application Support/TextMate/Managed/Bundles/LaTeX.tmbundle/Support/bin/texMate.py", line 127, in run_latex runObj = Popen(ltxcmd+" "+shell_quote(texfile),shell=True,stdout=PIPE,stdin=PIPE,stderr=STDOUT,close_fds=True) UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 1: ordinal not in range(128)
