### PR TITLE
Fix the behaviour of “Trash aux files”

### DIFF
--- a/Support/bin/texMate.py
+++ b/Support/bin/texMate.py
@@ -614,7 +614,12 @@ if __name__ == '__main__':
             texStatus, isFatal, numErrs, numWarns = run_makeindex(fileName)
 
     elif texCommand == 'clean':
-        texCommand = 'latexmk -CA '
+        auxiliary_file_extension = ['aux', 'bbl', 'bcf', 'blg', 'fdb_latexmk',
+                                    'fls', 'fmt', 'ini', 'log', 'out', 'maf',
+                                    'mtc', 'mtc1', 'pdfsync', 'run.xml',
+                                    'synctex.gz', 'toc']
+        texCommand = 'rm ' + ' '.join(
+            ['*.' + extension for extension in auxiliary_file_extension])
         runObj = Popen(texCommand,shell=True,stdout=PIPE,stdin=PIPE,stderr=STDOUT,close_fds=True)
         commandParser = ParseLatexMk(runObj.stdout,True,fileName)
 


### PR DESCRIPTION
Hi,

this pull request should fix the behaviour of “Trash aux files”. Currently “Trash aux files” does not remove most auxiliary files. It (theoretically) however removes the generated PDF/PS file. This pull request should change this behaviour. We now keep the generated PS/PDF file while we remove the most common auxiliary files. This commit should fix #43 and #83.

Kind regards,
  René 
