### PR TITLE
Make LaTeX Citation more robust

### DIFF
--- a/Support/lib/LaTeXUtils.rb
+++ b/Support/lib/LaTeXUtils.rb
@@ -101,9 +101,9 @@ module LaTeX
       @@paths[extension] ||= ([`#{texpath}kpsewhich -show-path=#{extension}`.chomp.split(/:!!|:/)].flatten.map{|i| i.sub(/\/*$/,'/')}).unshift(relative).unshift("")
       @@paths[extension].each do |path|
         testpath = File.expand_path(File.join(path,filename + "." + extension))
-        return testpath if File.exist?(testpath)
+        return testpath if File.exist?(testpath) && !File.directory?(testpath)
         testpath = File.expand_path(File.join(path,filename))
-        return testpath if File.exist?(testpath)
+        return testpath if File.exist?(testpath) && !File.directory?(testpath)
       end
       return nil
     end


### PR DESCRIPTION
Hi,

this pull request should (hopefully) fix the following issues:
- c48a26a: #72 Bug in cite completion
- 1e33112: #74 Problem with cite when one of the Bib files is not found
- c48a26a: The Citation command tried to search file locations which are (usually) part of a generic macro. E.g.: We would try to locate the file `#1` and fail if we have the macro described below. In reality `#1` is only a placeholder for the first argument — the real file name — of the macro.

``` latex
\newcommand{\codeinput}[1]
{
    \begin{leftbar}
        \input{Code/#1}
    \end{leftbar}
}
```

Kind regards,
  René
