### PR TITLE
Track changes commands for the macros from trackchanges.sty

### DIFF
--- a/Snippets/Track Changes Add Editor.tmSnippet
+++ b/Snippets/Track Changes Add Editor.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>\\addeditor{$TM_SELECTED_TEXT$1} $0</string>
+	<key>keyEquivalent</key>
+	<string>~@E</string>
+	<key>name</key>
+	<string>Add Editor</string>
+	<key>tabTrigger</key>
+	<string>tced</string>
+	<key>uuid</key>
+	<string>FBDC1437-C0A6-4452-A1AF-A57CF4AE4209</string>
+</dict>
+</plist>

--- a/Snippets/Track Changes Add.tmSnippet
+++ b/Snippets/Track Changes Add.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>\\add[${1:editor}]{$TM_SELECTED_TEXT$2} $0</string>
+	<key>keyEquivalent</key>
+	<string>~@+</string>
+	<key>name</key>
+	<string>Add</string>
+	<key>tabTrigger</key>
+	<string>tc+</string>
+	<key>uuid</key>
+	<string>2C3EE370-04D1-43B6-BB8D-808DE606FD00</string>
+</dict>
+</plist>

--- a/Snippets/Track Changes Annote.tmSnippet
+++ b/Snippets/Track Changes Annote.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>\\annote[${1:editor}]{$TM_SELECTED_TEXT$3}{${2:Note...}} $0</string>
+	<key>keyEquivalent</key>
+	<string>~@A</string>
+	<key>name</key>
+	<string>Annote</string>
+	<key>tabTrigger</key>
+	<string>tcannote</string>
+	<key>uuid</key>
+	<string>BAC489C4-2395-486A-92ED-BBEFB00D3B3D</string>
+</dict>
+</plist>

--- a/Snippets/Track Changes Change.tmSnippet
+++ b/Snippets/Track Changes Change.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>\\change[${1:editor}]{$TM_SELECTED_TEXT$3}{${2:New text}} $0</string>
+	<key>keyEquivalent</key>
+	<string>~@C</string>
+	<key>name</key>
+	<string>Change</string>
+	<key>tabTrigger</key>
+	<string>tcchange</string>
+	<key>uuid</key>
+	<string>7F831D32-FAB4-4EE0-A9EE-24BDA73CFB71</string>
+</dict>
+</plist>

--- a/Snippets/Track Changes Note.tmSnippet
+++ b/Snippets/Track Changes Note.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>\\note[${1:editor}]{$TM_SELECTED_TEXT$2} $0</string>
+	<key>keyEquivalent</key>
+	<string>~@N</string>
+	<key>name</key>
+	<string>Note</string>
+	<key>tabTrigger</key>
+	<string>tcnote</string>
+	<key>uuid</key>
+	<string>F54C7432-9F81-4274-9A43-1E3B4D3081A3</string>
+</dict>
+</plist>

--- a/Snippets/Track Changes Remove.tmSnippet
+++ b/Snippets/Track Changes Remove.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>\\remove[${1:editor}]{$TM_SELECTED_TEXT$2} $0</string>
+	<key>keyEquivalent</key>
+	<string>~@-</string>
+	<key>name</key>
+	<string>Remove</string>
+	<key>tabTrigger</key>
+	<string>tc-</string>
+	<key>uuid</key>
+	<string>DD175BAB-F63F-4DEB-8AB8-ACE124FA8B28</string>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -63,6 +63,7 @@
 			<dict>
 				<key>items</key>
 				<array>
+					<string>FBDC1437-C0A6-4452-A1AF-A57CF4AE4209</string>
 					<string>DD175BAB-F63F-4DEB-8AB8-ACE124FA8B28</string>
 					<string>F54C7432-9F81-4274-9A43-1E3B4D3081A3</string>
 					<string>7F831D32-FAB4-4EE0-A9EE-24BDA73CFB71</string>

--- a/info.plist
+++ b/info.plist
@@ -17,7 +17,7 @@
 		<string>A7B97D14-AE83-11D9-8B45-000D93B6E43C</string>
 	</array>
 	<key>description</key>
-	<string>Support for the &lt;a href="http://www.latex-project.org/"&gt;LaTeX&lt;/a&gt; typesetting system, the de facto standard for scientific papers.</string>
+	<string>Support for the &lt;a href=&quot;http://www.latex-project.org/&quot;&gt;LaTeX&lt;/a&gt; typesetting system, the de facto standard for scientific papers.</string>
 	<key>mainMenu</key>
 	<dict>
 		<key>excludedItems</key>
@@ -54,9 +54,24 @@
 			<string>7B194B41-B253-46E5-9EB9-523F43E7ED2F</string>
 			<string>D10F1CAC-BF1D-456D-B1E5-6AA5E3DD40ED</string>
 			<string>8F41368E-4E01-41A9-8FCF-19D4A4032AE2</string>
+			<string>------------------------------------</string>
+			<string>17B509AB-9308-4E87-BCE0-7F736372A005</string>
 		</array>
 		<key>submenus</key>
 		<dict>
+			<key>17B509AB-9308-4E87-BCE0-7F736372A005</key>
+			<dict>
+				<key>items</key>
+				<array>
+					<string>DD175BAB-F63F-4DEB-8AB8-ACE124FA8B28</string>
+					<string>F54C7432-9F81-4274-9A43-1E3B4D3081A3</string>
+					<string>7F831D32-FAB4-4EE0-A9EE-24BDA73CFB71</string>
+					<string>BAC489C4-2395-486A-92ED-BBEFB00D3B3D</string>
+					<string>2C3EE370-04D1-43B6-BB8D-808DE606FD00</string>
+				</array>
+				<key>Name</key>
+				<string>Track Changes</string>
+			</dict>
 			<key>02459F02-DB4A-4439-B9FE-BAF4040ED287</key>
 			<dict>
 				<key>items</key>

--- a/info.plist
+++ b/info.plist
@@ -69,7 +69,7 @@
 					<string>BAC489C4-2395-486A-92ED-BBEFB00D3B3D</string>
 					<string>2C3EE370-04D1-43B6-BB8D-808DE606FD00</string>
 				</array>
-				<key>Name</key>
+				<key>name</key>
 				<string>Track Changes</string>
 			</dict>
 			<key>02459F02-DB4A-4439-B9FE-BAF4040ED287</key>
@@ -273,6 +273,7 @@
 	<string>LaTeX</string>
 	<key>ordering</key>
 	<array>
+		<string>17B509AB-9308-4E87-BCE0-7F736372A005</string>
 		<string>B3E6DCF7-6323-4229-94D7-59996BDF07EC</string>
 		<string>BC36A3C7-F9B2-47D4-83FB-2BEB93F14889</string>
 		<string>5AED5DFA-F084-4F12-8A06-D51C78E91D05</string>


### PR DESCRIPTION
What Has He Done?
--------------------------

I've added five (5) commands that can tab-complete or wrap around selected text to give the 5 main editing macros:
 - `\note[editor]{Note...}`;
 - `\annote[editor]{Text to annote}{Note...}`;
 - `\add[editor]{Text to add}`;
 - `\remove[editor]{Text to remove}`;
 - `\change[editor]{Text to change}{New text}`;

and the `\addeditor{}` command from the [track changes package](http://trackchanges.sourceforge.net/) for LaTeX.

The files are placed inside their own menu ‘Track Changes’.

Foreseen issues where I'm open to ideas about what to do.
-------------------------------------------------------------------------------

 - The ‘Track Changes’ menu could be moved inside another menu item, such as project management.
 - The name of the menu could be be confuse with some form of git/mercurial version management system. Perhaps it should be changed.
 - Other obvious things I've missed.
