### PR TITLE
Fix broken file path formatting when viewing PDF in TM

### DIFF
--- a/Support/bin/texmate.py
+++ b/Support/bin/texmate.py
@@ -505,7 +505,7 @@ def run_viewer(viewer, texfile_path, pdffile_path,
             if isfile(pdffile_path):
                 print('''<script type="text/javascript">
                          window.location="file://{}"
-                         </script>'''.format(quote(pdffile_path)))
+                         </script>'''.format(quote(pdffile_path.encode('utf8'))))
             else:
                 print("File does not exist: {}".format(pdffile_path))
     else:


### PR DESCRIPTION
Calls to urllib.quote/urllib.parse.quote
(python2 and 3, respectively), would crash for file
paths containing special characters. Fix by utf-8 encoding
the file path.