### PR TITLE
Removed 'pstricks' from latex_indicators

### DIFF
--- a/Support/bin/texmate.py
+++ b/Support/bin/texmate.py
@@ -648,7 +648,7 @@ def construct_engine_command(ts_directives, tm_engine, packages):
         latex
 
     """
-    latex_indicators = {'pstricks', 'xyling', 'pst-asr', 'OTtablx'}
+    latex_indicators = {'xyling', 'pst-asr', 'OTtablx'}
     xelatex_indicators = {'xunicode'}
     lualatex_indicators = {'luacode'}
 


### PR DESCRIPTION
On my machine, PSTricks graphics work fine together with XeLaTeX -- switching to pdfLaTeX just because this package is imported in a LaTeX file is unnecessary and may break things for some users.