### PR TITLE
Put only keywords on their own line.

### DIFF
--- a/Support/bin/latextidy.pl
+++ b/Support/bin/latextidy.pl
@@ -88,7 +88,7 @@ foreach (@pieces){
 #Put @keywords on their own line.
 
 	foreach $keyword (@keywords) {
-		s/(\\$keyword\b/\n$&/g;
+		s/\\$keyword\b/\n$&/g;
 	}
 
 #Newlines before each \begin and \end. After each \end{}

--- a/Support/bin/latextidy.pl
+++ b/Support/bin/latextidy.pl
@@ -88,7 +88,7 @@ foreach (@pieces){
 #Put @keywords on their own line.
 
 	foreach $keyword (@keywords) {
-		s/(\\$keyword)/\n$1/g;
+		s/(\\$keyword\W)/\n$1/g;
 	}
 
 #Newlines before each \begin and \end. After each \end{}

--- a/Support/bin/latextidy.pl
+++ b/Support/bin/latextidy.pl
@@ -88,7 +88,7 @@ foreach (@pieces){
 #Put @keywords on their own line.
 
 	foreach $keyword (@keywords) {
-		s/(\\$keyword\W)/\n$1/g;
+		s/(\\$keyword\b/\n$&/g;
 	}
 
 #Newlines before each \begin and \end. After each \end{}


### PR DESCRIPTION
Currently, latextidy puts commands that start with a keyword on their own line. For example, it puts \part{...} on its own line, which it should, but also puts \partial on its own line, which it shouldn't. This patch stops tidy from acting on words longer than the keyword.