### PR TITLE
Tidy: put \bibitem's on own line

### DIFF
--- a/Support/bin/latextidy.pl
+++ b/Support/bin/latextidy.pl
@@ -106,6 +106,11 @@ foreach (@pieces){
 
 	s/(\\item)(.*?)(\\item)/$1$2\n$3/g;
 	s/(\\item)/\n$1/g;
+	
+#Newlines before each \bibitem.
+
+	s/(\\bibitem)(.*?)(\\bibitem)/$1$2\n$3/g;
+	s/(\\bibitem)/\n$1/g;
 
 #\n before each \[  and after each \]
 #Add newlines after all "\\" and "\\[...]"


### PR DESCRIPTION
I thought to add \bibitem as a keyword, but noticed that \item is not. Just to be safe, I copied the pattern of \item for \bibitem.