### PR TITLE
Tidy: Add new lines after \cr

### DIFF
--- a/Support/bin/latextidy.pl
+++ b/Support/bin/latextidy.pl
@@ -108,12 +108,12 @@ foreach (@pieces){
 	s/(\\item)/\n$1/g;
 
 #\n before each \[  and after each \]
-#Add newlines after all "\\" and "\\[...]"
+#Add newlines after all "\\", "\cr", and "\\[...]"
 
 	s/[^\\](\\\[)/\n$1/g;
 	s/(\\\])/$1\n/g;
 
-	s/(\\\\)\s/$1\n/g;
+	s/(\\\\|\\cr)\s/$1\n/g;
 	s/(\\\\\[)(.*?)(\])\s/$1$2$3\n/g;
 
 


### PR DESCRIPTION
Add new lines after `\cr` in addition to `\\` and `\\[...]`.