### PR TITLE
Update TeX primitives

### DIFF
--- a/Syntaxes/TeX.plist
+++ b/Syntaxes/TeX.plist
@@ -23,7 +23,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\\)(backmatter|else|fi|frontmatter|mainmatter|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?)\b</string>
+			<string>(\\)(backmatter|else|fi|frontmatter|mainmatter|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|vbox|vmode|void|x)?)\b</string>
 			<key>name</key>
 			<string>keyword.control.tex</string>
 		</dict>

--- a/Syntaxes/TeX.plist
+++ b/Syntaxes/TeX.plist
@@ -23,7 +23,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\\)(backmatter|else|fi|frontmatter|ftrue|mainmatter|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|undefined|vbox|vmode|void|x)?)\b</string>
+			<string>(\\)(backmatter|else|fi|frontmatter|mainmatter|if(case|cat|dim|eof|false|hbox|hmode|inner|mmode|num|odd|true|undefined|vbox|vmode|void|x)?)\b</string>
 			<key>name</key>
 			<string>keyword.control.tex</string>
 		</dict>


### PR DESCRIPTION
These were found when using vscode extension `latex-workshop`. See
- https://github.com/James-Yu/LaTeX-Workshop/pull/2666
- https://github.com/jlelong/vscode-latex-basics/pull/43

Since GitHub uses syntaxes from current repo to highlight markdown code blocks with language set to `(la)tex`, the problem in TeX syntax file can be seen from the example below:
```tex
\ftrue vs \iftrue

% source: The eTeX manual, sec. 3.4 _Status Enquiries_ (texdoc etex)
1: \if      8: \ifmmode 15: \iftrue
2: \ifcat   9: \ifinner 16: \iffalse
3: \ifnum   10: \ifvoid 17: \ifcase
4: \ifdim   11: \ifhbox 18: \ifdefined
5: \ifodd   12: \ifvbox 19: \ifcsname
6: \ifvmode 13: \ifx    20: \iffontchar
7: \ifhmode 14: \ifeof

% ltdefns.dtx
\def\@namedef#1{\expandafter\def\csname #1\endcsname}

% ltdefns.dtx
\def\@ifundefined#1{%
  \ifcsname#1\endcsname\@ifundefin@d@i\else\@ifundefin@d@ii\fi{#1}}

% latex2e kernel, ltlatex.dtx
\begingroup
  % ...
  \def\parseunicodedataV#1;#2\relax{%
    \loop
      \unless\ifnum\count0>"#1 %
        \catcode\count0=11 %
        \advance\count0 by 1 %
    \repeat
  }%
  % ...
\endgroup
```